### PR TITLE
Updates to allow arbitrary metdata to be stored within build-versions…

### DIFF
--- a/src/com/boxboat/jenkins/library/SemVer.groovy
+++ b/src/com/boxboat/jenkins/library/SemVer.groovy
@@ -20,9 +20,12 @@ class SemVer implements Comparable<SemVer>, Serializable {
 
     String buildInfo
 
-    SemVer(String version) {
+    String previousVersion
+
+    SemVer(String version, String previousVersion = "") {
         this.isPreRelease = false
         this.hasBuildInfo = false
+        this.previousVersion = previousVersion
 
         // regex from https://github.com/semver/semver/issues/232
         def regex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$/
@@ -78,7 +81,7 @@ class SemVer implements Comparable<SemVer>, Serializable {
     }
 
     SemVer copy() {
-        return new SemVer(this.toString())
+        return new SemVer(this.toString(), this.getPreviousVersion())
     }
 
     SemVer copyNoPrerelease() {

--- a/src/com/boxboat/jenkins/library/buildVersions/GitBuildVersions.groovy
+++ b/src/com/boxboat/jenkins/library/buildVersions/GitBuildVersions.groovy
@@ -136,6 +136,9 @@ class GitBuildVersions implements Serializable {
             data.put("metadata", metadata)
         }
         def yamlStr = YamlUtils.dump(data)
+        Config.pipeline.sh """
+            mkdir -p "${dir}"
+        """
         Config.pipeline.writeFile(file: yamlFile, text: yamlStr, encoding: "Utf8")
     }
 

--- a/src/com/boxboat/jenkins/library/buildVersions/GitBuildVersions.groovy
+++ b/src/com/boxboat/jenkins/library/buildVersions/GitBuildVersions.groovy
@@ -63,10 +63,7 @@ class GitBuildVersions implements Serializable {
                 cat "${txtFile}"
             """)?.trim()
         } else if (Config.pipeline.fileExists(yamlFile)) {
-            String yamlVersion = Config.pipeline.sh(returnStdout: true, script: """
-                cat "${yamlFile}"
-            """)?.trim()
-            Map<Object, Object> yamlData = YamlUtils.load(yamlVersion) as Map<Object, Object>
+            Map<Object, Object> yamlData = Config.pipeline.readYaml(file: yamlFile) as Map<Object, Object>
             result = yamlData.getOrDefault("version", "")
         }
 
@@ -79,27 +76,10 @@ class GitBuildVersions implements Serializable {
         def yamlFile = "${path}.yaml"
 
         if (Config.pipeline.fileExists(yamlFile)) {
-            String yamlVersion = Config.pipeline.sh(returnStdout: true, script: """
-                cat "${yamlFile}"
-            """)?.trim()
-            Map<Object, Object> yamlData = YamlUtils.load(yamlVersion) as Map<Object, Object>
+            Map<Object, Object> yamlData = Config.pipeline.readYaml(file: yamlFile) as Map<Object, Object>
             return yamlData.getOrDefault("metadata", new LinkedHashMap<Object, Object>()) as Map<Object, Object>
         }
         return null
-    }
-
-    Map<Object, Object> addEventImageVersionMetadata(String event, Image image, Map<Object, Object> imageMetadataMap) {
-        Map<Object, Object> metaMap = new LinkedHashMap<>()
-        metaMap.putAll(imageMetadataMap)
-        def meta = getEventImageVersionMetadata(event, image)
-
-        def tag_key = "image_tag_${Utils.alphaNumericUnderscoreLower(image.path)}"
-        if (meta != null){
-            Map<Object, Object> imageMetaData = new LinkedHashMap<>()
-            imageMetadataMap.put("metadata", meta)
-            metaMap.put(tag_key, imageMetadataMap)
-        }
-        return metaMap
     }
 
     boolean writeEventImageVersion(String event, Image image, String outFile, String format) {
@@ -156,7 +136,6 @@ class GitBuildVersions implements Serializable {
             data.put("metadata", metadata)
         }
         def yamlStr = YamlUtils.dump(data)
-        Config.pipeline.echo "${yamlStr}"
         Config.pipeline.writeFile(file: yamlFile, text: yamlStr, encoding: "Utf8")
     }
 
@@ -174,10 +153,7 @@ class GitBuildVersions implements Serializable {
                 cat "${txtFile}"
             """)?.trim()
         } else if (Config.pipeline.fileExists(yamlFile)) {
-            String yamlVersion = Config.pipeline.sh(returnStdout: true, script: """
-                cat "${yamlFile}"
-            """)?.trim()
-            Map<Object, Object> yamlData = YamlUtils.load(yamlVersion) as Map<Object, Object>
+            Map<Object, Object> yamlData = Config.pipeline.readYaml(file: yamlFile) as Map<Object, Object>
             version = yamlData.getOrDefault("version", "")
             previousVersion = yamlData.getOrDefault("previousVersion", "")
         }

--- a/src/com/boxboat/jenkins/library/git/GitCommit.groovy
+++ b/src/com/boxboat/jenkins/library/git/GitCommit.groovy
@@ -1,0 +1,23 @@
+package com.boxboat.jenkins.library.git
+
+import java.time.Instant
+
+/**
+ * Stores git commit data scraped from git log
+ */
+class GitCommit implements Serializable {
+    String author
+    String hash
+    String date
+    String subject
+    String body
+
+    Instant getInstant() {
+        return Instant.ofEpochSecond(Long.parseLong(date))
+    }
+
+    String toString() {
+        return new String("{\"author\":\"${author}\",\"hash\":\"${hash}\",\"date\":\"${getInstant().toString()}\",\"subject\":\"${subject}\",\"body\":\"${body}\"}")
+    }
+
+}

--- a/src/com/boxboat/jenkins/library/git/GitRepo.groovy
+++ b/src/com/boxboat/jenkins/library/git/GitRepo.groovy
@@ -145,11 +145,11 @@ class GitRepo implements Serializable {
         List<GitCommit> commitList = new ArrayList<>()
         result.each {
             def c = new GitCommit()
-            c.author = it.author
-            c.hash = it.hash
-            c.date = it.date
-            c.subject = it.subject
-            c.body = it.body
+            c.author = it?.author
+            c.hash = it?.hash
+            c.date = it?.date
+            c.subject = it?.subject
+            c.body = it?.body
             commitList.add(c)
         }
         return commitList

--- a/src/com/boxboat/jenkins/pipeline/deploy/BoxDeploy.groovy
+++ b/src/com/boxboat/jenkins/pipeline/deploy/BoxDeploy.groovy
@@ -320,7 +320,6 @@ class BoxDeploy extends BoxBase<DeployConfig> implements Serializable {
         if (yamlPathScript) {
             Config.pipeline.sh yamlPathScript
         }
-        getImageTagsMetadata()
     }
 
     List<Environment> allEnvironments() {

--- a/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
+++ b/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
@@ -5,6 +5,7 @@ import com.boxboat.jenkins.library.Utils
 import com.boxboat.jenkins.library.config.Config
 import com.boxboat.jenkins.library.config.PromoteConfig
 import com.boxboat.jenkins.library.docker.Registry
+import com.boxboat.jenkins.library.git.GitCommit
 import com.boxboat.jenkins.library.promote.Promotion
 import com.boxboat.jenkins.pipeline.BoxBase
 
@@ -21,6 +22,15 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
 
     protected boolean versionChange = true
     protected boolean writebackBuildVersions = true
+
+    protected String gitCommitToTag
+    protected String gitTagToTag
+    protected SemVer nextSemVer
+    protected String promoteVersionString
+
+    protected List<GitCommit> commits = new ArrayList<>()
+
+    protected Map<Object, Object> metadata = new LinkedHashMap<>()
 
     BoxPromote(Map config = [:]) {
         super(config)
@@ -85,15 +95,15 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
 
     /**
      * Parse the promoteToEvent to determine the type of promote (tag/release, or tag/<pre-release>)
-    **/
+     **/
     String getTagType() {
         return promotion.promoteToEvent.substring("tag/".length())
     }
 
     /**
      * Get the git commit (or git tag) that used for this promote
-    **/
-    List<String> getGitCommit(){
+     **/
+    List<String> getGitCommit() {
         String gitCommitToTag
         String gitTagToTag
         def buildVersions = Config.getBuildVersions()
@@ -125,7 +135,7 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
 
     /**
      * Get the current semVer for promotion
-    **/
+     **/
     SemVer getCurrSemVer() {
         // getBuildVersions returns singleton - If buildVersions already checked out, will initialized object
         def buildVersions = Config.getBuildVersions()
@@ -134,7 +144,7 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
 
     /**
      * Get the next semVer to promote to
-    **/
+     **/
     SemVer getNextSemVer(String tagType) {
         def nextSemVer = currSemVer?.copy()
         // Return the user defined version if it is set, else get nextSemVer like usual
@@ -146,9 +156,9 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
             //   2. If this is a prerelease event but our override is a release
             //   3. If this tag < the current tag
             if (!promoteToSemVer.isValid ||
-                (tagType == "release" && promoteToSemVer.isPreRelease) ||
-                (tagType != "release" && !promoteToSemVer.isPreRelease) ||
-                (nextSemVer && nextSemVer.compareTo(promoteToSemVer) > 0)) {
+                    (tagType == "release" && promoteToSemVer.isPreRelease) ||
+                    (tagType != "release" && !promoteToSemVer.isPreRelease) ||
+                    (nextSemVer && nextSemVer.compareTo(promoteToSemVer) > 0)) {
                 writebackBuildVersions = false
 
                 // If we are not writing back to build versions (version less than current version),
@@ -163,14 +173,17 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
         // If nextSemVer doesn't exist or its version without prerelease is smaller than baseSemVer, use baseSemVer
         if (nextSemVer == null || !nextSemVer.isValid || (baseSemVer.compareTo(nextSemVer.copyNoPrerelease()) > 0)) {
             nextSemVer = baseSemVer.copy()
+            nextSemVer.setPreviousVersion(currSemVer.toString())
         } else if (tagType == "release") {
             nextSemVer.patch++
+            nextSemVer.setPreviousVersion(currSemVer.toString())
         }
 
         if (tagType != "release") {
             def releaseSemVer = buildVersions.getRepoEventVersion(gitRepo.getRemotePath(), config.gitTagPrefix, "tag/release")
             if (releaseSemVer != null && releaseSemVer.isValid && releaseSemVer >= nextSemVer) {
                 nextSemVer = releaseSemVer.copy()
+                nextSemVer.setPreviousVersion(releaseSemVer.toString())
                 nextSemVer.patch++
             }
             nextSemVer.incrementPreRelease(tagType)
@@ -181,7 +194,7 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
 
     /**
      * Set versionChange instance var
-    **/
+     **/
     void setVersionChange(String gitCommitToTag, String gitTagToTag) {
         SemVer currSemVer = getCurrSemVer()
         if (currSemVer != null && !config.gitTagDisable && (gitCommitToTag || gitTagToTag)) {
@@ -196,9 +209,9 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
 
             def semVerReferenceHash = gitRepo.getTagReferenceHash(fullSemVer)?.trim()
             if (semVerReferenceHash &&
-                !promoteToVersion && (
+                    !promoteToVersion && (
                     semVerReferenceHash == gitCommitToTag ||
-                    semVerReferenceHash == gitRepo.getTagReferenceHash(fullGitTagToTag))) {
+                            semVerReferenceHash == gitRepo.getTagReferenceHash(fullGitTagToTag))) {
                 versionChange = false
                 Config.pipeline.echo "No version changes detected"
             }
@@ -207,7 +220,7 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
 
     /**
      * Print out each of the images being promoted
-    **/
+     **/
     void prePromoteMessages(String promoteVersionString) {
         imageSummary = "Images"
         config.images.each { image ->
@@ -218,7 +231,7 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
 
     /**
      * If not an automated run, wait for user to click the button
-    **/
+     **/
     void waitForUserConfirmation(String promoteVersionString) {
         if (!trigger) {
             Config.pipeline.timeout(time: 10, unit: 'MINUTES') {
@@ -229,7 +242,7 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
 
     /**
      * Iterate through images and retag and push to new registry. Write to build versions if not a user-defined promotion version
-    **/
+     **/
     void retagImages(String pushEvent, String promoteVersionString, SemVer nextSemVer) {
         def buildVersions = Config.getBuildVersions()
         def pushRegistries = config.getEventRegistries(pushEvent)
@@ -281,17 +294,17 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
                 }
             }
             if (writebackBuildVersions) {
-                buildVersions.setEventImageVersion(pushEvent, image, promoteVersionString)
+                buildVersions.setEventImageVersion(pushEvent, image, promoteVersionString, metadata)
             }
         }
         if (writebackBuildVersions) {
-            buildVersions.setRepoEventVersion(gitRepo.getRemotePath(), config.gitTagPrefix, pushEvent, nextSemVer)
+            buildVersions.setRepoEventVersion(gitRepo.getRemotePath(), config.gitTagPrefix, pushEvent, nextSemVer, metadata)
         }
     }
 
     /**
      * Determine promotion type (release/non-release) and retag images
-    **/
+     **/
     void promoteImages(String tagType, String promoteVersionString, SemVer nextSemVer) {
         def buildVersions = Config.getBuildVersions()
         if (tagType == "release") {
@@ -335,29 +348,45 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
         }
     }
 
-    def promote() {
-        def tagType = getTagType()
+    /**
+     * Called during promote() after promotions have been prepared. You can use this to populate the metadata map
+     * 
+     * Override and extend this method to insert metadata on the promotion data stored in build-versions
+     **/
+    def addPromotionMetadata() {
+    }
 
+    def preparePromotions() {
         List<String> gitTagInfo = getGitCommit()
-        String gitCommitToTag = gitTagInfo[0]
-        String gitTagToTag = gitTagInfo[1]
+        gitCommitToTag = gitTagInfo[0]
+        gitTagToTag = gitTagInfo[1]
 
-        SemVer nextSemVer
-        String promoteVersionString
-
-
-        nextSemVer = getNextSemVer(tagType)
+        nextSemVer = getNextSemVer(getTagType())
         promoteVersionString = nextSemVer.toString()
         setVersionChange(gitCommitToTag, gitTagToTag)
 
+        if (gitCommitToTag) {
+            commits = gitRepo.getCommitsBetween(nextSemVer.getPreviousVersion(), gitCommitToTag)
+        } else if (gitTagToTag) {
+            commits = gitRepo.getCommitsBetween(nextSemVer.getPreviousVersion(), gitTagToTag)
+        }
+    }
+
+    def performPromotions() {
         if (versionChange) {
             prePromoteMessages(promoteVersionString)
             waitForUserConfirmation(promoteVersionString)
 
-            promoteImages(tagType, promoteVersionString, nextSemVer)
+            promoteImages(getTagType(), promoteVersionString, nextSemVer)
             saveBuildVersions()
             tagGitRepo(gitCommitToTag, gitTagToTag, promoteVersionString)
         }
+    }
+
+    def promote() {
+        preparePromotions()
+        addPromotionMetadata()
+        performPromotions()
     }
 
     def summary() {

--- a/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
+++ b/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
@@ -350,7 +350,7 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
 
     /**
      * Called during promote() after promotions have been prepared. You can use this to populate the metadata map
-     * 
+     *
      * Override and extend this method to insert metadata on the promotion data stored in build-versions
      **/
     def addPromotionMetadata() {


### PR DESCRIPTION
Addresses #89 

During image promotion pipelines extract commit log between SemVer releases and store in `BoxPromote`. Allow downstream clients the ability to add arbitrary metadata object to image-versions and repo-versions for promotion pipelines. Users may wish to associate issues to a release  For example, you can now leverage the commits between semvers to scrape issues and store them with the build-version:

Override `BoxPromote.addPromotionMetadata`:
```
    @Override
    def addPromotionMetadata() {
        Pattern pattern = Pattern.compile("[A-Z]{2,}-\\d+")
        Set<String> issues = new LinkedHashSet<>()
        commits.each {
            Matcher matcher = pattern.matcher(it.subject)
            while(matcher.find()) {
                issues.add(matcher.group(0))
            }
        }
        metadata.put("issues", issues.toArray())
    }
```

Results in a build-versions entry like:
```
version: 0.3.18
metadata:  
  issues: [ABC-1, XY-123, XYZ-1234]
```

`BoxDeploy` has a new method `getImageTagsMetadata` that will allow you to retrieve the metadata associated with images you are about to deploy returning something like:
```
demo/dockhand-demo-app:
  version: 0.3.18
  metadata:
    issues: [ABC-1, XY-123, XYZ-1234]
```

This change does not break backwards compatibility but will migrate build-versions `.txt` files that previously contained just the SemVer text to a yaml format minimally containing:
```
version: <version-string>
```

This conversion will occur as images are build and promoted by jenkins-dockhand