### PR TITLE
Rename getImageTagsMetadata to readImageTagsMetdata

### DIFF
--- a/src/com/boxboat/jenkins/pipeline/deploy/BoxDeploy.groovy
+++ b/src/com/boxboat/jenkins/pipeline/deploy/BoxDeploy.groovy
@@ -215,7 +215,7 @@ class BoxDeploy extends BoxBase<DeployConfig> implements Serializable {
         }
     }
 
-    Map<Object, Object> getImageTagsMetadata() {
+    Map<Object, Object> readImageTagsMetadata() {
         def buildVersions = Config.getBuildVersions()
         Map<Object, Object> imageTagsMetadata = new LinkedHashMap<>()
         config.images.each { Image image ->


### PR DESCRIPTION
closes #92 

`getImageTagsMetadata` can lead to unexpected behavior if a derived class uses the field name `imageTagsMetadata`