### PR TITLE
Align Slack notifications for Jenkins app and webhook

### DIFF
--- a/src/com/boxboat/jenkins/library/notify/SlackJenkinsAppNotifyTarget.groovy
+++ b/src/com/boxboat/jenkins/library/notify/SlackJenkinsAppNotifyTarget.groovy
@@ -18,10 +18,14 @@ class SlackJenkinsAppNotifyTarget extends BaseConfig<SlackJenkinsAppNotifyTarget
                 color = "#36a64f"
                 break
         }
-        message = "*${URLDecoder.decode(Config.pipeline.env.JOB_NAME, "UTF-8")}* (<${Config.pipeline.env.BUILD_URL}|build #${Config.pipeline.env.BUILD_NUMBER}>)\n" + message
         def slackSendOptions = [
-                color  : color,
-                message: message,
+            message: "*${URLDecoder.decode(Config.pipeline.env.JOB_NAME, "UTF-8")}* (<${Config.pipeline.env.BUILD_URL}|build #${Config.pipeline.env.BUILD_NUMBER}>)",
+            attachments: [
+                [
+                    color: color,
+                    text : message,
+                ]
+            ]
         ]
         if (channel) {
             slackSendOptions["channel"] = channel


### PR DESCRIPTION
The notification format when using the SlackJenkinsAppNotifyTarget class differs from the SlackWebHookNotifyTarget format. This commit aligns the two message formats to be the same and fixes a slight malformatting issue present only in SlackJenkinsAppNotifyTarget which mangles URLs at the end of the message.